### PR TITLE
Moving CollectorCollectionFactory from ProviderInvoker to CompilerPass

### DIFF
--- a/Collector/CollectorCollection.php
+++ b/Collector/CollectorCollection.php
@@ -9,7 +9,7 @@ class CollectorCollection implements CollectorInterface
     /**
      * @var array
      */
-    private $collectors;
+    private $collectors = array();
 
     /**
      * @param Collector $collector

--- a/Collector/Factory/CollectorCollectionFactory.php
+++ b/Collector/Factory/CollectorCollectionFactory.php
@@ -7,10 +7,18 @@ use Flagbit\Bundle\MetricsBundle\Collector\CollectorCollection;
 class CollectorCollectionFactory
 {
     /**
+     * @param \Beberlei\Metrics\Collector\Collector[] $collectors
+     *
      * @return CollectorCollection
      */
-    public function create()
+    public function create(array $collectors)
     {
-        return new CollectorCollection();
+        $collectorCollection = new CollectorCollection();
+
+        foreach ($collectors as $collector) {
+            $collectorCollection->addCollector($collector);
+        }
+
+        return $collectorCollection;
     }
 }

--- a/DependencyInjection/Compiler/MetricsCollectorPass.php
+++ b/DependencyInjection/Compiler/MetricsCollectorPass.php
@@ -21,7 +21,7 @@ class MetricsCollectorPass implements CompilerPassInterface
         }
 
         $definition = $container->getDefinition('flagbit_metrics.provider_invoker');
-        $collection = $container->getDefinition('flagbit_metrics.factory.collector_collection');
+        $collection = $container->getDefinition('flagbit_metrics.collector.collector_collection');
 
         foreach ($container->findTaggedServiceIds('metrics.provider') as $id => $tags) {
             $collectors = array();
@@ -38,7 +38,7 @@ class MetricsCollectorPass implements CompilerPassInterface
             }
 
             if (!empty($collectors)) {
-                $definition->addMethodCall('addMetricsProvider', array(new Reference($id), $collection->addMethodCall('create', array($collectors))));
+                $definition->addMethodCall('addMetricsProvider', array(new Reference($id), $collection->setArguments(array($collectors))));
             }
         }
     }

--- a/DependencyInjection/Compiler/MetricsCollectorPass.php
+++ b/DependencyInjection/Compiler/MetricsCollectorPass.php
@@ -12,6 +12,7 @@ class MetricsCollectorPass implements CompilerPassInterface
      * Add tagged metrics.provider services to flagbit_metrics.collector service
      *
      * @param ContainerBuilder $container
+     * @throws \InvalidArgumentException
      */
     public function process(ContainerBuilder $container)
     {
@@ -20,6 +21,7 @@ class MetricsCollectorPass implements CompilerPassInterface
         }
 
         $definition = $container->getDefinition('flagbit_metrics.provider_invoker');
+        $collection = $container->getDefinition('flagbit_metrics.factory.collector_collection');
 
         foreach ($container->findTaggedServiceIds('metrics.provider') as $id => $tags) {
             $collectors = array();
@@ -36,7 +38,7 @@ class MetricsCollectorPass implements CompilerPassInterface
             }
 
             if (!empty($collectors)) {
-                $definition->addMethodCall('addMetricsProvider', array(new Reference($id), $collectors));
+                $definition->addMethodCall('addMetricsProvider', array(new Reference($id), $collection->addMethodCall('create', array($collectors))));
             }
         }
     }

--- a/Provider/ProviderInvoker.php
+++ b/Provider/ProviderInvoker.php
@@ -4,6 +4,7 @@ namespace Flagbit\Bundle\MetricsBundle\Provider;
 
 use Beberlei\Metrics\Collector\Collector;
 use Flagbit\Bundle\MetricsBundle\Collector\Factory\CollectorCollectionFactory;
+use Flagbit\Bundle\MetricsBundle\Collector\CollectorInterface;
 
 class ProviderInvoker
 {
@@ -34,15 +35,10 @@ class ProviderInvoker
 
     /**
      * @param ProviderInterface $provider
-     * @param Collector[]              $collectors
+     * @param CollectorInterface $collectorsCollection
      */
-    public function addMetricsProvider(ProviderInterface $provider, array $collectors)
+    public function addMetricsProvider(ProviderInterface $provider, CollectorInterface $collectorsCollection)
     {
-        $collectorsCollection = $this->factory->create();
-        foreach ($collectors as $collector) {
-            $collectorsCollection->addCollector($collector);
-        }
-
         $this->providers[] = array(
             'provider' => $provider,
             'collector' => $collectorsCollection,

--- a/Provider/ProviderInvoker.php
+++ b/Provider/ProviderInvoker.php
@@ -2,7 +2,6 @@
 
 namespace Flagbit\Bundle\MetricsBundle\Provider;
 
-use Beberlei\Metrics\Collector\Collector;
 use Flagbit\Bundle\MetricsBundle\Collector\Factory\CollectorCollectionFactory;
 use Flagbit\Bundle\MetricsBundle\Collector\CollectorInterface;
 
@@ -17,14 +16,6 @@ class ProviderInvoker
      * @var array
      */
     private $providers = array();
-
-    /**
-     * @param CollectorCollectionFactory $factory
-     */
-    public function __construct(CollectorCollectionFactory $factory)
-    {
-        $this->factory = $factory;
-    }
 
     public function collectMetrics()
     {

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -21,6 +21,7 @@
             class="%flagbit_metrics.collector.collector_collection.class%"
             factory-service="flagbit_metrics.factory.collector_collection"
             factory-method="create">
+            <argument type="collection" />
         </service>
     </services>
 </container>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -7,6 +7,7 @@
     <parameters>
         <parameter key="flagbit_metrics.provider_invoker.class">Flagbit\Bundle\MetricsBundle\Provider\ProviderInvoker</parameter>
         <parameter key="flagbit_metrics.factory.collector_collection.class">Flagbit\Bundle\MetricsBundle\Collector\Factory\CollectorCollectionFactory</parameter>
+        <parameter key="flagbit_metrics.collector.collector_collection.class">Flagbit\Bundle\MetricsBundle\Collector\CollectorCollection</parameter>
     </parameters>
 
     <services>
@@ -14,6 +15,12 @@
 
         <service id="flagbit_metrics.provider_invoker" class="%flagbit_metrics.provider_invoker.class%">
             <argument type="service" id="flagbit_metrics.factory.collector_collection" />
+        </service>
+
+        <service id="flagbit_metrics.collector.collector_collection"
+            class="%flagbit_metrics.collector.collector_collection.class%"
+            factory-service="flagbit_metrics.factory.collector_collection"
+            factory-method="create">
         </service>
     </services>
 </container>

--- a/Tests/Collector/CollectorCollectionTest.php
+++ b/Tests/Collector/CollectorCollectionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Flagbit\Bundle\MetricsBundle\Tests\Collector;
+
 use Flagbit\Bundle\MetricsBundle\Collector\CollectorCollection;
 
 class CollectorCollectionTest extends \PHPUnit_Framework_TestCase

--- a/Tests/Collector/Factory/CollectorCollectionFactoryTest.php
+++ b/Tests/Collector/Factory/CollectorCollectionFactoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Flagbit\Bundle\MetricsBundle\Tests\Collector\Factory;
+
 use Flagbit\Bundle\MetricsBundle\Collector\Factory\CollectorCollectionFactory;
 
 class CollectorCollectionFactoryTest extends \PHPUnit_Framework_TestCase
@@ -14,11 +16,21 @@ class CollectorCollectionFactoryTest extends \PHPUnit_Framework_TestCase
         $this->factory = new CollectorCollectionFactory();
     }
 
-    public function testCreate()
+    public function testCreateEmpty()
     {
         $this->assertInstanceOf(
             'Flagbit\Bundle\MetricsBundle\Collector\CollectorCollection',
-            $this->factory->create()
+            $this->factory->create(array())
+        );
+    }
+
+    public function testCreate()
+    {
+        $collector = $this->getMock('Beberlei\Metrics\Collector\Collector');
+
+        $this->assertInstanceOf(
+            'Flagbit\Bundle\MetricsBundle\Collector\CollectorCollection',
+            $this->factory->create(array($collector))
         );
     }
 } 

--- a/Tests/DependencyInjection/Compiler/MetricsCollectorPassTest.php
+++ b/Tests/DependencyInjection/Compiler/MetricsCollectorPassTest.php
@@ -3,7 +3,6 @@
 namespace Flagbit\Bundle\MetricsBundle\Tests\DependencyInjection\Compiler;
 
 use Flagbit\Bundle\MetricsBundle\DependencyInjection\Compiler\MetricsCollectorPass;
-use Symfony\Component\DependencyInjection\Reference;
 
 class MetricsCollectorPassTest extends \PHPUnit_Framework_TestCase
 {
@@ -38,9 +37,8 @@ class MetricsCollectorPassTest extends \PHPUnit_Framework_TestCase
             ->method('hasDefinition')
             ->will($this->returnValue(true));
 
-        $container->expects($this->once())
+        $container->expects($this->exactly(2))
             ->method('getDefinition')
-            ->with('flagbit_metrics.provider_invoker')
             ->will($this->returnValue($definition));
 
         $container->expects($this->atLeastOnce())
@@ -48,12 +46,8 @@ class MetricsCollectorPassTest extends \PHPUnit_Framework_TestCase
             ->with('metrics.provider')
             ->will($this->returnValue($services));
 
-        $definition->expects($this->once())
-            ->method('addMethodCall')
-            ->with('addMetricsProvider', array(
-                new Reference('my_metric_collector'),
-                array(new Reference('beberlei_metrics.collector.librato'))
-            ));
+        $definition->expects($this->exactly(2))
+            ->method('addMethodCall');
 
         $metricsCollectorPass = new MetricsCollectorPass();
         $metricsCollectorPass->process($container);

--- a/Tests/DependencyInjection/Compiler/MetricsCollectorPassTest.php
+++ b/Tests/DependencyInjection/Compiler/MetricsCollectorPassTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Flagbit\Bundle\MetricsBundle\Tests\DependencyInjection\Compiler;
+
 use Flagbit\Bundle\MetricsBundle\DependencyInjection\Compiler\MetricsCollectorPass;
 use Symfony\Component\DependencyInjection\Reference;
 

--- a/Tests/Provider/ProviderInvokerTest.php
+++ b/Tests/Provider/ProviderInvokerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Flagbit\Bundle\MetricsBundle\Tests\Provider;
+
 use Flagbit\Bundle\MetricsBundle\Provider\ProviderInvoker;
 
 class ProviderInvokerTest extends \PHPUnit_Framework_TestCase
@@ -10,7 +12,7 @@ class ProviderInvokerTest extends \PHPUnit_Framework_TestCase
     private $factory;
 
     /**
-     * @var MetricsCollector
+     * @var ProviderInvoker
      */
     private $metricsProvider;
 
@@ -22,43 +24,23 @@ class ProviderInvokerTest extends \PHPUnit_Framework_TestCase
 
     public function testAddMetricsProvider()
     {
-        $collector = $this->getMock('Beberlei\Metrics\Collector\Collector');
+        $collectorCollection = $this->getMock('Flagbit\Bundle\MetricsBundle\Collector\CollectorCollection');
         $provider = $this->getMock('Flagbit\Bundle\MetricsBundle\Provider\ProviderInterface');
 
-        $this->getCollectorCollection($collector);
-
-        $this->metricsProvider->addMetricsProvider($provider, array($collector));
+        $this->metricsProvider->addMetricsProvider($provider, $collectorCollection);
     }
 
     public function testCollectMetrics()
     {
-        $collector = $this->getMock('Beberlei\Metrics\Collector\Collector');
+        $collectorCollection = $this->getMock('Flagbit\Bundle\MetricsBundle\Collector\CollectorCollection');
         $provider = $this->getMock('Flagbit\Bundle\MetricsBundle\Provider\ProviderInterface');
-        $collectorCollection = $this->getCollectorCollection($collector);
 
         $provider
             ->expects($this->once())
             ->method('collectMetrics')
             ->with($collectorCollection);
 
-        $this->metricsProvider->addMetricsProvider($provider, array($collector));
+        $this->metricsProvider->addMetricsProvider($provider, $collectorCollection);
         $this->metricsProvider->collectMetrics();
-    }
-
-    private function getCollectorCollection($collector)
-    {
-        $collectorCollection = $this->getMock('Flagbit\Bundle\MetricsBundle\Collector\CollectorCollection');
-
-        $this->factory
-            ->expects($this->once())
-            ->method('create')
-            ->will($this->returnValue($collectorCollection));
-
-        $collectorCollection
-            ->expects($this->once())
-            ->method('addCollector')
-            ->with($collector);
-
-        return $collectorCollection;
     }
 }

--- a/Tests/Provider/ProviderInvokerTest.php
+++ b/Tests/Provider/ProviderInvokerTest.php
@@ -18,8 +18,7 @@ class ProviderInvokerTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->factory = $this->getMock('Flagbit\Bundle\MetricsBundle\Collector\Factory\CollectorCollectionFactory');
-        $this->metricsProvider = new ProviderInvoker($this->factory);
+        $this->metricsProvider = new ProviderInvoker();
     }
 
     public function testAddMetricsProvider()


### PR DESCRIPTION
In the last CodeReview, we discussed about the possibility to move the CollectorCollectionFactory out of the ProviderInvoker, since it looked kind of out of place there. I did a refactoring, trying not to break the API for the developer.
